### PR TITLE
src/Session: read_all_lines: use Java `toString` instead of `as_string`

### DIFF
--- a/src/Session.fz
+++ b/src/Session.fz
@@ -414,14 +414,14 @@ module Session (sessions lock_free.Map String Session,
                          return_nil_on_error, pretty_print bool)
                         option (list String) =>
     res := lm.instate_self (outcome (list String)) ()->
-      io.file.use (list String) lm file.as_string io.file.mode.read ()->
+      io.file.use (list String) lm file.toString io.file.mode.read ()->
         data := (io.buffered lm).read_fully
         lines := String.from_bytes data
         lines.split "\n"
 
     match res
       e error =>
-        log "error reading from path {file}: {e}"
+        log "error reading from path {file.toString}: {e}"
         if return_nil_on_error
           nil
         else


### PR DESCRIPTION
`as_string` just returns a generic information string about it being an instance of a path. We need the string to contain the actual path, hence we use the `toString` implemented in the JDK.