### PR TITLE
src/util/url_encoded: fix `from_urlencoded` returning empty strings

### DIFF
--- a/src/util/url_encoded.fz
+++ b/src/util/url_encoded.fz
@@ -12,7 +12,10 @@ module url_encoded is
   #
   module from_urlencoded(data String) String =>
 
-    s(c, i) String =>
+    s (c codepoint, i i32) String
+    post
+      !result.is_empty
+    =>
         if c = "+"
           " "
         else if c = "%" && (i < data.codepoint_length - 2)


### PR DESCRIPTION
This also fixes the problem of sessions and connections not being tied together correctly.