### PR TITLE
use new feature encodings.percent from base library

### DIFF
--- a/src/util/url_encoded.fz
+++ b/src/util/url_encoded.fz
@@ -22,6 +22,19 @@ module url_encoded is
     form_data
 
 
+  # Strip non-alphanumeric characters from a string
+  #
+  module strip_non_alpha_numeric(s String) String =>
+
+    for res := "", (if (("0" <= c) && (c <= "9")) || ("a" <= c && c <= "z") || ("A" <= c && c <= "Z") || c = "_"
+                      res + c
+                    else
+                      res + "_")
+        c in s.as_codepoints
+        i := 0, i + 1
+    else
+      res
+
 
   # HTML-encode a string
   #


### PR DESCRIPTION
@maxteufel not sure if you had a good reason to avoid the index call or if the feature `strip_non_alpha_numeric` is still needed