### PR TITLE
src: move template features to separate file

### DIFF
--- a/src/document.fz
+++ b/src/document.fz
@@ -31,40 +31,6 @@ module document is
       page
 
 
-  # return the "attractivelink" template
-  #
-  module attractive_link(to, title String) String =>
-    get_template "attractivelink.html" ["##LINK##","/{to}","##TITLE##",title].as_list
-
-
-  # return the "page" template
-  #
-  module page_link(to, title String) String =>
-    get_template "page.html" ["##LINK##","/{to}","#TITLE##",title].as_list
-
-
-  # dispatch the html content
-  #
-  module doc_links(doc_file_name String) String =>
-    parts := doc_file_name.split "/"
-    if parts.count < 2
-      ""
-    else
-      for res := "", res +  """
-                              <a class="shylink shylinkfix" href="/docs/{doc_path}">
-                                  {name}
-                              </a> •
-                            """
-          part in parts
-          name0 := Java.java.net.URLDecoder_static.decode part "UTF-8"
-          name1 := name0.get.split "("
-          name := name1[0]
-          end := (doc_file_name.find part).get + parts.count
-          doc_path := doc_file_name.substring 0
-      else
-        res
-
-
   # read lines from the path and return them in a list of string
   # NYI: pretty printing
   #
@@ -98,28 +64,5 @@ module document is
   # same as read_all_lines (2 args) but without the option of
   # returning nil on error
   #
-  read_all_lines (file Java.java.nio.file.Path) list String =>
+  module read_all_lines (file Java.java.nio.file.Path) list String =>
     (read_all_lines file false).get
-
-
-  # returns the content of the file
-  #
-  module get_template(filename String, repl list String) String =>
-    not_found := "--template {filename} not found--"
-    match content.template filename
-      template_id identifier =>
-        match template_id.file_to_send
-          p Java.java.nio.file.Path =>
-            i := mut 0
-            lines := read_all_lines p
-            for
-              res := "", res + rs + "\n"
-              rs in lines
-            while i.get < repl.count
-            do
-              _ := rs.replace repl[i.get] repl[i.get + 1]
-              i <- i.get+1
-            else
-              res
-          nil => not_found
-      * => not_found

--- a/src/template.fz
+++ b/src/template.fz
@@ -1,0 +1,64 @@
+# -----------------------------------------------------------------------
+#
+#  Tokiwa Software GmbH, Germany
+#
+#  Source code of Fuzion webserver feature template
+#
+# -----------------------------------------------------------------------
+
+# template -- features for working with templates
+#
+module template is
+
+
+  # looks for a file named `filename` in the `templates/` folder
+  # and applies the replacments given in the list `repl`
+  #
+  apply (filename String, repl list (tuple String String)) String =>
+    not_found := "--template {filename} not found--"
+    match content.template filename
+      template_id identifier =>
+        match template_id.file_to_send
+          p Java.java.nio.file.Path =>
+            lines := document.read_all_lines p
+            for
+              res := (String.join lines "\n"), res.replace r.values.0 r.values.1
+              r in repl
+            else
+              res
+          nil => not_found
+      * => not_found
+
+
+  # apply the given parameters to the `attractivelink.html` template
+  #
+  module attractive_link (to, title String) String =>
+    apply "attractivelink.html" [("##LINK##" ,"/{to}"), ("##TITLE##", title)].as_list
+
+
+  # apply the given parameters to the `page.html` template
+  #
+  module page_link (to, title String) String =>
+    apply "page.html" [("##LINK##", "/{to}"), ("##TITLE##", title)].as_list
+
+
+  # dispatch the html content
+  #
+  module doc_links (doc_file_name String) String =>
+    parts := doc_file_name.split "/"
+    if parts.count < 2
+      ""
+    else
+      for res := "", res +  """
+                              <a class="shylink shylinkfix" href="/docs/{doc_path}">
+                                  {name}
+                              </a> •
+                            """
+          part in parts
+          name0 := Java.java.net.URLDecoder_static.decode part "UTF-8"
+          name1 := name0.get.split "("
+          name := name1[0]
+          end := (doc_file_name.find part).get + parts.count
+          doc_path := doc_file_name.substring 0
+      else
+        res


### PR DESCRIPTION
Also rename the `get_template` feature as `apply` for clearer naming, as well as fixing some issues with the replacing in the `apply` feature.