### PR TITLE
get_content, change result type

### DIFF
--- a/src/document2.fz
+++ b/src/document2.fz
@@ -28,9 +28,9 @@ module document2 (module page String,
   permitted := content.access_permitted session.user[util.hashable_unit] page
 
 
-  # get file content as list of strings
+  # get file content as array of strings
   #
-  module get_content list String =>
+  module get_content array String =>
     lm ! ()->
       res := (mutate.array String).new lm
 
@@ -67,7 +67,7 @@ module document2 (module page String,
             res.add (navigation false)
         nil => res.add "<p>404: page not found</p>"
 
-      res.as_list
+      res.as_array
 
 
   # add session-specific information to the html


### PR DESCRIPTION
since `as_list` in mutable array is this:
```
  # create a list from this array
  #
  public redef as_list list T =>
    # since array is mutable,
    # we first copy the elements
    # to an immutable array.
    as_array.as_list
```