### PR TITLE
Jenkinsfile: check out `flang_dev` from `main` branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
 
         dir('flang_dev') {
           checkout scmGit(
-            branches: [[name: 'master']],
+            branches: [[name: 'main']],
             userRemoteConfigs: [[credentialsId: '7a3054c1-90e8-4a0c-a4ec-1304a6c2c38f',
               url: 'https://git.tokiwa.software/tokiwa/flang_dev.git']])
         }


### PR DESCRIPTION
The `master` branch no longer exists.