### PR TITLE
src/session_document: add last changed timestamp to rendered page

### DIFF
--- a/src/session_document.fz
+++ b/src/session_document.fz
@@ -62,7 +62,11 @@ module session_document (module page String,
 
           res.add "</div>"
 
-          # NYI: last changed!
+          match io.file.stat data_path.as_string true
+            e error =>
+              session.log "error retrieving file metadata in session_document get_content: {e}"
+            metadata io.file.meta_data =>
+              res.add "<div class='last-changed'>last changed: {metadata.time}</div>"
 
           if permitted
             res.add (navigation false)


### PR DESCRIPTION
For now, this is just the UNIX timestamp. Once the base library supports it, we can also format this as a proper date.

Link: https://github.com/tokiwa-software/fuzion/pull/6000
Link: https://github.com/tokiwa-software/fzweb/issues/150