### PR TITLE
remove calls to `as_equatable` and `as_equatable_switch`

### DIFF
--- a/src/Session.fz
+++ b/src/Session.fz
@@ -237,7 +237,7 @@ module Session (sessions lock_free.Map String Session,
         logger.log "No session found in map for id: {id}"
         nil
       s Session =>
-        if s.client.as_equatable = c.as_equatable
+        if s.client = c
           s
         else
           logger.log "Mismatch of clients for session with id: {id}"

--- a/src/path.fz
+++ b/src/path.fz
@@ -49,7 +49,7 @@ is
   public starts_with(p path) bool =>
     is_absolute = p.is_absolute &&
       p.names.count <= names.count &&
-      (names.take p.names.count).as_equatable=p.names.as_equatable
+      (names.take p.names.count) = p.names
 
   public normalize path =>
     path names is_absolute
@@ -58,7 +58,7 @@ is
     (if is_absolute then "/" else "") + (if names.is_empty then "." else String.join names "/" )
 
   public redef type.equality(a, b path.this) bool =>
-    a.is_absolute=b.is_absolute && a.names.as_equatable=b.names.as_equatable
+    a.is_absolute = b.is_absolute && a.names = b.names
 
   public type.of(str String) path =>
     t := str.trim

--- a/src/user.fz
+++ b/src/user.fz
@@ -19,7 +19,7 @@ module user (module base_dir String) is
   # verify username password combination
   #
   module verify_login (username, password String) =>
-    if name.as_equatable_switch = username || email.as_equatable_switch = username || login.as_equatable_switch = username
+    if name = username || email = username || login = username
       match password_hash
         nil => false
         hash String =>
@@ -165,14 +165,14 @@ module user (module base_dir String) is
   #
   module type.get (login_or_email String) =>
     get_user u->
-      u.login.as_equatable_switch = login_or_email || u.email.as_equatable_switch = login_or_email
+      u.login = login_or_email || u.email = login_or_email
 
 
   # get user by a deletion token
   #
   module type.get_by_deletion_token (token String) =>
     get_user u->
-      u.deletion_token.as_equatable_switch = token
+      u.deletion_token = token
 
 
   module type.get_user(predicate user->bool) outcome user =>


### PR DESCRIPTION
These have been removed from the base library.