### PR TITLE
Dockerfile: install UTF-8 locale in builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,11 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   wget \
   ditaa \
   inkscape \
-  unzip
+  unzip \
+  locales
 RUN ln -s /usr/bin/clang-18 /usr/bin/clang
-ENV FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true"
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG=en_US.utf8 FUZION_REPRODUCIBLE_BUILD="true" PRECONDITIONS="true" POSTCONDITIONS="true"
 WORKDIR /fzweb
 COPY . .
 WORKDIR /fzweb/fuzion


### PR DESCRIPTION
This is an attempt to fix a `java.nio.file.InvalidPathException` during writing out the class files.