### PR TITLE
src/logger: log timestamps with messages

### DIFF
--- a/src/logger.fz
+++ b/src/logger.fz
@@ -19,14 +19,15 @@ module logger is
 
   # Logger function that outputs to the console
   module log(c String|error) =>
-    say "{logger.thread_id}: {c ? s String => s | e error => e.as_string}"
+    say "{time.now.get} {logger.thread_id}: {c ? s String => s | e error => e.as_string}"
 
   # Logger function that writes to a file
   module log(log_path String, msg String) =>
+    m := "{time.now.get} {logger.thread_id}: {msg}"
+
     res := io.file.use unit log_path io.file.mode.append ()->
-        m := "{logger.thread_id}: {msg}"
         (io.file.writer.write "{m}\n".utf8).error
 
     match res
-      unit => say "{logger.thread_id}: {msg}"  # Also log to console
+      unit => say m # Also log to console
       e error => say "*** failed to write to log: {e}"

--- a/src/user.fz
+++ b/src/user.fz
@@ -35,7 +35,7 @@ module user (module base_dir String) is
   # log a message to this users' log file
   #
   module log (s String) =>
-    logger.log log_path s # NYI: add timestamp
+    logger.log log_path s
 
 
   # name of the user


### PR DESCRIPTION
Also, in `logger.log(log_path, msg)`, create log string only once. This should slightly improve performance.