### PR TITLE
src/user: reorder predicate in `user.get`

### DIFF
--- a/src/user.fz
+++ b/src/user.fz
@@ -158,7 +158,7 @@ module user (module base_dir String) is
   #
   module type.get (username, password String) =>
     get_user u->
-      u.verify_login username password && !u.has_registration_token
+      !u.has_registration_token && u.verify_login username password
 
 
   # get user by loginname or email


### PR DESCRIPTION
This suppresses the "successful login" log message when the login fails due to the registration still not being complete.