### PR TITLE
disallow creating paths that are not normalized

### DIFF
--- a/src/path.fz
+++ b/src/path.fz
@@ -76,7 +76,11 @@ is
           # we have double dots, ignore them and increase counter
           (r.0+1, r.1)
         else if r.0 > 0
+          # we previously encountered double dots.
+          # ignore this element too and decrease the counter.
           (r.0-1, r.1)
         else
+          # no double dots encountered previously,
+          # we need to include this element in the final path
           (r.0, [t]++r.1)
     path ([".."]*dotdot ++ names).as_array is_absolute


### PR DESCRIPTION
_normalized_ here means:
- omit single dots
- omit redundant slashes (empty names)
- omit ".." unless path is relative and dotdots are at the start

fixes #164

tested by: `printf "GET /../smtp_config.txt HTTP/1.0\r\n\r\n" |nc localhost 8080`
this then prints:
```
1: GET /../smtp_config.txt
1: new session 1 53be9d77-8cec-4b59-a987-e478a70d39aa for [127, 0, 0, 1] user --nil--
1: *** forbidding access to absolute or non-normalized path /../smtp_config.txt.
```
