### PR TITLE
perfomance: get_title, do not split file first

### DIFF
--- a/src/document.fz
+++ b/src/document.fz
@@ -37,7 +37,7 @@ module document is
   module read_all_lines (file path,
                          return_nil_on_error, pretty_print bool)
                         option (list String) =>
-    match util.read_file_as_string file.as_string
+    match util.read_file_as_string file
       e error =>
         logger.log "error reading from path {file.as_string}: {e}"
         if return_nil_on_error
@@ -77,21 +77,23 @@ module document is
     title_start_close := ">"
     title_end := "</h1>"
 
-    for
-      line in document.read_all_lines page_file
-      start_open := (line.find title_start_open).val -1
-      start_close :=
-        if start_open >= 0
-          (line.find title_start_close (start_open + title_start_open.byte_length)).val -1
-        else -1
-      end :=
-        if start_close >= 0
-          (line.find title_end (start_close + title_start_close.byte_length)).val -1
-        else -1
-    until start_close >= 0 && end >= 0
-      line.substring (start_close + title_start_close.byte_length) end
-    else
-      strip_html (content.file_path link).as_string
+    match util.read_file_as_string page_file
+      error =>
+        "-- error reading {page_file} --"
+      str String =>
+        start_open := (str.find title_start_open).val -1
+        start_close :=
+          if start_open >= 0
+            (str.find title_start_close (start_open + title_start_open.byte_length)).val -1
+          else -1
+        end :=
+          if start_close >= 0
+            (str.find title_end (start_close + title_start_close.byte_length)).val -1
+          else -1
+        if start_close >= 0 && end >= 0
+          str.substring (start_close + title_start_close.byte_length) end
+        else
+          strip_html (content.file_path link).as_string
 
 
   # create attribute_map based on the entry provided


### PR DESCRIPTION
rough measurement on tutorial page:
```
~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)130$ for i in {1..50}; do curl -o /dev/null -s -w "%{time_total}\n" http://127.0.0.1:8080/tutorial/index; done | sort | awk '{ total += $1; count++ } END { print "Avg:", total/count }'
Avg: 0.615952
```
vs
```
~/openvscode-server-fuzion/vscode-fuzion/fuzion (main)$ for i in {1..50}; do curl -o /dev/null -s -w "%{time_total}\n" http://127.0.0.1:8080/tutorial/index; done | sort | awk '{ total += $1; count++ } END { print "Avg:", total/count }'
Avg: 0.421403
```

still slow but a little faster...