### PR TITLE
add benchmark for message via event connection

### DIFF
--- a/benchmarks/benchmarks.fz
+++ b/benchmarks/benchmarks.fz
@@ -21,15 +21,29 @@ benchmarks =>
 
 
   session_document_get_content(where String) =>
-    s := Session (lock_free.Map String Session .empty) (list u8 .empty) nil
-    sd := session_document where s
-    _ := sd.get_content
-
-    x := bench ()->
+    x := io.Out.instate _ io.Out.blackhole ()->
+      s := Session (lock_free.Map String Session .empty) (list u8 .empty) nil
+      sd := session_document where s
       _ := sd.get_content
+
+      bench ()->
+        _ := sd.get_content
 
     say "session_document.get_content {where} iter/s: {x}"
 
 
+  session_event_msg(where String) =>
+    x := io.Out.instate _ io.Out.blackhole ()->
+      s := Session (lock_free.Map String Session .empty) (list u8 .empty) nil
+      s.set_current where
+
+      bench ()->
+        _ := s.event_msg
+
+    say "Session.event_msg {where} iter/s: {x}"
+
+
   session_document_get_content "tutorial"
   session_document_get_content "."
+  session_event_msg "tutorial"
+  session_event_msg "."

--- a/src/Session.fz
+++ b/src/Session.fz
@@ -295,16 +295,19 @@ module Session (sessions lock_free.Map String Session,
       .as_array
 
 
-  # send current page content to the client
+  # the message to send via an event connection
   #
-  module send_content =>
-    msg := """
+  module event_msg =>
+    """
       id: 0
       event: content
       {prepend_data current_page.read.get_content}\n
     """
 
-    send_data msg
+  # send current page content to the client
+  #
+  module send_content =>
+    send_data event_msg
     send_push_history
 
 


### PR DESCRIPTION
example run on my machine:
```
session_document.get_content tutorial iter/s: 4.9
session_document.get_content . iter/s: 39.7
Session.event_msg tutorial iter/s: 1.5
Session.event_msg . iter/s: 9.85
```