### PR TITLE
change default thread pool size

### DIFF
--- a/src/run.fz
+++ b/src/run.fz
@@ -24,7 +24,7 @@ run =>
 
     # start a thread pool
     # NYI: UNDER DEVELOPMENT: thread_pool size should be determined programmatically
-    concur.thread_pool 200 ()->
+    concur.thread_pool 4 ()->
 
       # the request accept loop
       do


### PR DESCRIPTION
For every thread there needs to be an effect environment, so it's a waste to have 200 threads.