### PR TITLE
fix fzweb checking for frozen pointers in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   libsodium-dev \
   openssh-client
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG=en_US.utf8 PATH="/fzweb/fuzion/build/bin:${PATH}" PRECONDITIONS="true" POSTCONDITIONS="true"
+ENV LANG=en_US.utf8 PATH="/fzweb/fuzion/build/bin:${PATH}"
 COPY --from=builder /fzweb /fzweb
 WORKDIR /fzweb
 RUN ln -sf /fzweb/flang_dev/content


### PR DESCRIPTION
relevant code from Runtime.java

    static final Map<Object, String> _frozenPointers_ = CHECKS ? Collections.synchronizedMap(new WeakHashMap<Object, String>()) : null;

This is one cause that performance of fzweb degrades and also a big memory leak