### PR TITLE
src/template: doc_links: make percent decoding more tolerant

### DIFF
--- a/src/template.fz
+++ b/src/template.fz
@@ -87,7 +87,7 @@ module template is
                             """
           part in parts
           name := encodings.percent
-            .decode_as_str part
+            .decode_as_str_tolerant part
             .get
             .split "("
             .first


### PR DESCRIPTION
This decreases the likelihood of a precondition failure due to the decoding returning an error.