### PR TITLE
change result type from array to Sequence in some places

### DIFF
--- a/src/Session.fz
+++ b/src/Session.fz
@@ -329,7 +329,7 @@ module Session (client net.ip_address,
 
   # returns nil on Not Found
   #
-  module add_session_info_to_html_bytes (b array u8) option (array u8) =>
+  module add_session_info_to_html_bytes (b Sequence u8) option (Sequence u8) =>
     activity
     # NYI
     # - ByteArray from flang_dev
@@ -345,7 +345,6 @@ module Session (client net.ip_address,
           .replace "##URL##" "/{cp.page}"
           .replace "##CONTENT##" (String.join a "\n")
           .utf8
-          .as_array
 
 
   # the message to send via an event connection

--- a/src/access.fz
+++ b/src/access.fz
@@ -27,16 +27,16 @@ module identifier (module file_to_send option path,
   # array u8 = success
   # nil = Not Found
   #
-  get_bytes (s Session) choice error nil (array u8) =>
+  get_bytes (s Session) choice error nil (Sequence u8) =>
     match file_to_send
       fts path =>
         match util.read_file fts
-          ba array u8 =>
+          ba Sequence u8 =>
             if is_html_template
               s.set_current (simple_path.val "")
               # NYI : UNDER DEVELOPMENT: ugly that we have to manually retag
               match s.add_session_info_to_html_bytes ba
-                a array u8 => a
+                a Sequence u8 => a
                 nil => nil
             else
               ba
@@ -49,10 +49,10 @@ module identifier (module file_to_send option path,
   module response (s Session) response =>
     # NYI: logging
     match get_bytes s
-      b array u8 =>
+      b Sequence u8 =>
         suffix := file_to_send.get.suffix
         attributes := map_of_strings [
-          ("Content-Length", b.length.as_string),
+          ("Content-Length", b.count.as_string),
           ("Content-Type", mime_types.get_mime_type suffix)
         ]
         response.new 200 attributes b

--- a/src/util/read_file.fz
+++ b/src/util/read_file.fz
@@ -18,12 +18,13 @@ module read_file_as_string(c choice String path) outcome String =>
 # read file p file and return
 # its contents as an array of bytes
 #
-module read_file(c choice String path) outcome (array u8) =>
+module read_file(c choice String path) outcome (Sequence u8) =>
   str := match c
     s String => s
     p path => p.as_string
-  # NYI: UNDER DEVELOPMENT cache these reads?
+  # NYI: UNDER DEVELOPMENT return the mapped buffer as an immutable Sequence
+  # instead of copying it to an array once we have resource areneas.
   io.file.use str io.file.mode.append ()->
     sz := (io.file.stat str false).val.size
     io.file.open.mmap 0 sz ()->
-      io.file.mapped_buffer.env.as_array
+      id (Sequence u8) io.file.mapped_buffer.env.as_array


### PR DESCRIPTION
Using `as_array` was/is kind of a premature optimization that I like the get rid of.