### PR TITLE
fix title bar (navtitle) on the library modules page

### DIFF
--- a/src/session_document.fz
+++ b/src/session_document.fz
@@ -394,7 +394,7 @@ module session_document (module page String,
       # we start with a link to the current page
       temp :=
         # we link to the docs if necessary
-        if page.starts_with "docs/"
+        if page.starts_with "docs/" && page != "docs/index"
           template.doc_links fn
         else
           page_link page


### PR DESCRIPTION
The title bar on the [library modules page](https://fzweb.fuzion-lang.dev/docs/index) is missing the last entry. 

This seems to fix it, but I did not fully understand it, so there might be a better solution.