### PR TITLE
Revert "Dockerfile: link release notes"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,5 @@ WORKDIR /fzweb
 RUN ln -sf /fzweb/flang_dev/content
 RUN ln -sf /fzweb/flang_dev/templates
 RUN ln -sf /fzweb/fuzion/build/modules /fzweb/flang_dev/content/api/link
-RUN ln -sf /fzweb/fuzion/build/release_notes.md /fzweb/flang_dev/content/pages/release_notes.txt
 ENTRYPOINT /fzweb/run
 EXPOSE 8080


### PR DESCRIPTION
Reverts tokiwa-software/fzweb#366

Now links to rendered markdown on GitHub, see [tokiwa/flang_dev#632](https://git.tokiwa.software/tokiwa/flang_dev/pulls/632)