### PR TITLE
build: remove obsolete rrd-antlr4 setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,6 @@ WORKDIR /fzweb
 COPY . .
 WORKDIR /fzweb/fuzion
 RUN make no-java build/fuzion.ebnf
-WORKDIR /fzweb/flang_dev/rrd-antlr4
-RUN sed -i 1,3d src/main/resources/railroad-diagram.css
-RUN mvn clean package
 WORKDIR /fzweb/flang_dev
 RUN make DITAA='java -jar /usr/share/ditaa/ditaa.jar' FZ='/fzweb/fuzion/build/bin/fz' FUZION_HOME='/fzweb/fuzion/build' build
 WORKDIR /fzweb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,12 +20,6 @@ pipeline {
             extensions: [submodule(parentCredentials: true, recursiveSubmodules: true)],
             userRemoteConfigs: [[credentialsId: '7a3054c1-90e8-4a0c-a4ec-1304a6c2c38f',
               url: 'https://git.tokiwa.software/tokiwa/flang_dev.git']])
-
-          dir('rrd-antlr4') {
-            checkout scmGit(
-              branches: [[name: 'af15d7d9151ce30a9b26bc8782a16643c93e3d6d']],
-              userRemoteConfigs: [[url: 'https://github.com/bkiers/rrd-antlr4.git']])
-          }
         }
       }
     }


### PR DESCRIPTION
This was previously used to generate railroad diagrams, but has been replaced with a different tool in [flang_dev#615](https://git.tokiwa.software/tokiwa/flang_dev/pulls/615)