### PR TITLE
specify type parameter explicitly to avoid error

### DIFF
--- a/src/runner.fz
+++ b/src/runner.fz
@@ -56,7 +56,7 @@ module runner is
           res := concur.atomic String .new ""
 
           add_to_res(str String) =>
-            _ := res.update o->"{o}{if o.is_empty then "" else "\n"}{str}"
+            _ := res.update (String->String) o->"{o}{if o.is_empty then "" else "\n"}{str}"
 
 
           fout := concur.thread_pool.env.submit _ ()->


### PR DESCRIPTION
Is it expected that the type parameter needs to be specified because of the following change?
```diff
diff --git a/modules/base/src/concur/atomic.fz b/modules/base/src/concur/atomic.fz
index d6d95baa8..4fb2ab40f 100644
--- a/modules/base/src/concur/atomic.fz
+++ b/modules/base/src/concur/atomic.fz
@@ -166,7 +166,7 @@ is
   #
   # returns the (old_value, new_value)
   #
-  public update(compute_new T->T) (T,T) =>
+  public update(F type : T->T, compute_new F) (T,T) =>
     for current_value := read
         new_value     := compute_new current_value
     while !(compare_and_set current_value new_value)
```