### PR TITLE
cleanup: call effect instance features via `env`

### DIFF
--- a/src/config_file.fz
+++ b/src/config_file.fz
@@ -37,7 +37,7 @@ module config_file (values lock_free.Map String String, p path) is
       data := values.items
                     .map (e -> "$(e.0): $(e.1)")
                     .as_string "\n"
-      (io.file.writer.write data.utf8)
+      (io.buffered io.file.file_mutate).writer.env.write data.utf8
 
     match res
       unit => unit

--- a/src/global.fz
+++ b/src/global.fz
@@ -66,3 +66,6 @@ module global : effect is
   module read_file_as_string(p path) =>
     files.access p ()->
       universe.read_file_as_string p
+
+
+  feeds.init

--- a/src/logger.fz
+++ b/src/logger.fz
@@ -17,6 +17,6 @@ module logger is
     m := "$(time.now.env.get): $(msg)"
 
     match (io.file.use unit log_path io.file.mode.append ()->
-            (io.file.writer.write "$(m)\n".utf8))
+            ((io.buffered io.file.file_mutate).writer.env.write "$(m)\n".utf8))
       unit => say m # Also log to console
       e error => say "*** failed writing to log: $(e)"

--- a/src/run.fz
+++ b/src/run.fz
@@ -17,7 +17,6 @@ run =>
     logger.log "started listening on port: $port"
 
     g := global
-    g.feeds.init
 
     # start a thread pool
     # NYI: UNDER DEVELOPMENT: thread_pool size should be determined programmatically


### PR DESCRIPTION
We should not call inner features of an effect and not go via `env`.