### PR TITLE
fix fzweb benchmarks running forever

### DIFF
--- a/benchmarks/benchmarks.fz
+++ b/benchmarks/benchmarks.fz
@@ -45,7 +45,7 @@ benchmarks =>
     x
 
   g := io.Out.instate _ io.Out.blackhole ()->
-    global
+    global false
 
   sites := [
     "idioms/index",

--- a/src/global.fz
+++ b/src/global.fz
@@ -8,7 +8,7 @@
 
 # effect for holding global state in the webserver
 #
-module global : effect is
+module global(init_feeds bool) : effect is
 
   max_open_sessions => 1E3
   eviction_count => 1E2
@@ -68,4 +68,5 @@ module global : effect is
       universe.read_file_as_string p
 
 
-  feeds.init
+  if init_feeds
+    feeds.init

--- a/src/run.fz
+++ b/src/run.fz
@@ -16,7 +16,7 @@ run =>
   res := net.server.start net.family.ipv4 net.protocol.tcp port ()->
     logger.log "started listening on port: $port"
 
-    g := global
+    g := global true
 
     # start a thread pool
     # NYI: UNDER DEVELOPMENT: thread_pool size should be determined programmatically


### PR DESCRIPTION
we must not start the feeds update threads for the benchmarks...